### PR TITLE
Show conversation content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A tool to analyse your upvote statistics for Steemit. Go to live website at http
 
 - [**upvotelist.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/master/upvotelist.php): A page opened up from index.php. It will show all articles voted on by a particular user, with the date and percentage of each vote, and a show ranking button that displays this user's contributation as a ranking against all other users who voted. You will also see how much in total the voter has contributed towards all of your articles during this time period in $ amount.
 
+- [**conversation.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/show-conversation-content/conversation.php): Look up your conversation records with another Steemit User. 
+
 - [**style.css**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/master/style.css): CSS Stylesheet for the whole website.
 
 - [**followers.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/master/followers.php): A list of Steemit Users ranked by number of followers. 50 users per page - any page can be selected and retrieved. A search box can also be used to locate a particular user.
@@ -18,6 +20,8 @@ A tool to analyse your upvote statistics for Steemit. Go to live website at http
 
 - [**effectiveSP.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/effective_SP_rank/effectiveSP.php): A list of Steemit Users ranked by the amount of effective SP. 50 users per page - any page can be selected and retrieved. A search box can also be used to locate a particular user.
 
+- [**reputation.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/show-conversation-content/reputation.php): A list of Steemit Users ranked by reputation score. 50 users per page - any page can be selected and retrieved. A search box can also be used to locate a particular user.
+
 - [**get_esp_rank.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/effective_SP_rank/get_esp_rank.php): PHP file that queries SteemSQL to find out the ranking of a paritcular user in terms of the amount of effective SP, and then allows the user to jump to that particular page on effectiveSP.php.
 
 - [**updateglobal.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/effective_SP_rank/updateglobal.php): Retrieve total_vesting_fund_steem and total_vesting_shares using the SteemJS API, and then update values in global.txt for calculation of SP.
@@ -25,6 +29,8 @@ A tool to analyse your upvote statistics for Steemit. Go to live website at http
 - [**global.txt**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/effective_SP_rank/global.txt): Text file containing the total_vesting_fund_steem and total_vesting_shares values needed to calculate a user's steem power from vesting shares. Updated periodically using updateglobal.php.
 
 - [**steemSQLconnect2.php**](https://github.com/Bulletproofmonk/MySteemitFriends/blob/automate_contribution_calculation/steemSQLconnect2.php): Connection to SteemSQL database in a separate php file, to be included in other pages that required SteemSQL connection..
+
+
 
 
 ## Folders

--- a/conversation.php
+++ b/conversation.php
@@ -81,7 +81,7 @@ $sth = $conn->prepare($sql);
 
 // execute SQL statement.	
 $sth->execute();    
-     echo '<table class="table table-sm table-responsive"><thead class="thead-inverse"><tr><th class="col-xs-2">Date</th><th class="col-xs-2">From</th><th class="col-xs-2">To</th><th class="col-xs-6">Comment Link</th></tr></thead><tbody>';
+     echo '<table class="table table-sm"><thead class="thead-inverse"><tr><th style="width:1%">Date</th><th style="width:1%">From</th><th style="width:1%">To</th><th>Comment Link</th></tr></thead><tbody>';
      
      // row number of $ button
      $rownum=0;
@@ -93,8 +93,10 @@ $sth->execute();
       echo $row[1];
       echo "</td><td>";
       echo $row[2];
-	  echo "</td><td class='text-nowrap'>";
-      echo '<a href="http://steemit.com/@'.$row[1].'/'.$row[3].'">'.$row[3].'</a>';
+	  echo "</td><td>";
+      echo '<p><a href="http://steemit.com/@'.$row[1].'/'.$row[3].'">Link to Comment</a></p>';
+	  echo '<div id='.$rownum.'><button type="button" class="btn btn-info" onClick="showArticle('.$rownum.',\''.$row[1].'\',\''.$row[3].'\')">Show Comment</button></div><br>';
+	  $rownum++;
       echo "</td></tr>";
       
     }
@@ -108,7 +110,43 @@ $sth->execute();
 
 </div>
 
+
 </body>
+
+
+<script src="https://cdn.steemjs.com/lib/latest/steem.min.js"></script>
+
+<script>
+	
+
+function showArticle(x,y,z) {
+
+// article url
+	var url=z;
+	
+// who is the author
+	var author=y;
+	
+// where comment text will be printed
+	var id=x;
+	document.getElementById(id).innerHTML="loading..";
+
+// update settings to new endpoint
+	steem.api.setOptions({ url: 'https://api.steemit.com'});
+
+// retrieve article text
+	
+	steem.api.getContent(author,url, function(err,result) {
+// print article text to correct location
+		document.getElementById(id).innerHTML=result.body;
+	});
+	
+}
+
+</script>
+
+
+
 	
 
 </html>

--- a/effectiveSP.php
+++ b/effectiveSP.php
@@ -16,7 +16,7 @@
 
     <script src="bootstrap/js/bootstrap.min.js"></script>
 
-    <link rel="stylesheet" type="text/css" href="style.css?2">
+    <link rel="stylesheet" type="text/css" href="style.css?3">
 
     <style>
 
@@ -250,7 +250,7 @@ echo '<form action="effectiveSP.php" method="get">Go To Page Number <input type=
 
 
     $sql = "
-SELECT convert(float, a.vesting_shares)-convert(float,a.delegated_vesting_shares)+convert(float,a.received_vesting_shares) AS effective_vests, a.name
+SELECT convert(float, a.vesting_shares)-convert(float,a.delegated_vesting_shares)+convert(float,a.received_vesting_shares) AS effective_vests, a.name, convert(float, a.vesting_shares) AS vests
 FROM
 (SELECT name, Substring(vesting_shares,0,PATINDEX('%VESTS%',vesting_shares)) AS vesting_shares, Substring(delegated_vesting_shares,0,PATINDEX('%VESTS%',delegated_vesting_shares)) AS delegated_vesting_shares, Substring(received_vesting_shares,0,PATINDEX('%VESTS%',received_vesting_shares)) AS received_vesting_shares
 FROM Accounts (NOLOCK)) a
@@ -273,7 +273,7 @@ echo '<table id="bigtable" class="table table-sm" style="background-color:#0f488
 
     
 
-echo '<thead class="thead-default mobile"><tr><th style="text-align: center;">Ranking</th><th>User Name</th><th>Effective SP</th></tr></thead>';
+echo '<thead class="thead-default mobile"><tr><th style="text-align: center;">Ranking</th><th>User Name</th><th class="alignright">Effective SP</th><th class="alignright">Own SP</th></tr></thead>';
 
     // print the results. If successful, magicmonk will be printed on page.
 
@@ -283,7 +283,8 @@ echo '<thead class="thead-default mobile"><tr><th style="text-align: center;">Ra
 		
 		$vests=$row[0];
 		$sp = $total_vesting_fund_steem * $vests / $total_vesting_shares;
-
+		$ownvests=$row[2];
+		$ownsp = $total_vesting_fund_steem * $ownvests / $total_vesting_shares;
 		
 
       echo '<tr><td style="text-align: center;">';
@@ -310,9 +311,12 @@ echo '<thead class="thead-default mobile"><tr><th style="text-align: center;">Ra
 
           
 
-          echo "</td><td>";
+          echo "</td><td class='alignright'>";
 
           echo number_format(round($sp));
+		 echo "</td><td class='alignright'>";
+
+          echo number_format(round($ownsp));
 
           echo "</td></tr>";
 

--- a/index.php
+++ b/index.php
@@ -95,7 +95,8 @@ fclose($my_file);
 if ($_GET["User"]) {
 // hide other buttons while upvotes data is loading.
 	echo '<script>
-      document.getElementById("rankingbtn").style.display = "none";
+      document.getElementById("rankingbtn").style.display = "none";	  
+	  document.getElementById("convbtn").style.display = "none";
 	  document.getElementById("upvotebtn").innerHTML = "Loading..";
 	  document.getElementById("logo").src="images/mmloading.gif";
 		
@@ -458,6 +459,7 @@ if ($rankmethod==1) {
 	      document.getElementById("pleasescroll").innerHTML = "<b><font color=yellow>Please <a href=\"#filterbox\">scroll down</a> to see the results.</font></b><br><br>";
 		  document.getElementById("upvotebtn").innerHTML = "Upvote Stats";
 		  document.getElementById("rankingbtn").style.display = "block";
+		  document.getElementById("convbtn").style.display = "inline";
 		  document.getElementById("logo").src="images/magicmonkhead.png";	
 		  </script>';
 		
@@ -494,6 +496,7 @@ $(function(){
 function upBtnTxt() {
 	document.getElementById("upvotebtn").innerHTML = "Loading.."; 
 	document.getElementById("rankingbtn").style.display = "none";
+	document.getElementById("convbtn").style.display = "none";
 	document.getElementById("logo").src="images/mmloading.gif";
 
 }
@@ -523,6 +526,7 @@ function loadRank(filename) {
 	document.getElementById("logo").src="images/mmloading.gif";
 	document.getElementById("rankingbtn").style.display = "none";
 	document.getElementById("upvotebtn").style.display = "none"; 
+	document.getElementById("convbtn").style.display = "none";
   	document.getElementById("ranking").style.margin="auto";
 	document.getElementById("ranking").style.marginTop="1.5rem";
 	document.getElementById("ranking").style.marginBottom="1.5rem";
@@ -545,6 +549,7 @@ function loadRank(filename) {
 		document.getElementById("pleasescroll").innerHTML = "<b><font color=#78EF15>Please <a href=\"#ranking\">scroll down</a> to see the ranking.</b><br><br>";
 		document.getElementById("upvotebtn").style.display = "inline"; 
 		document.getElementById("rankingbtn").style.display = "block";
+		document.getElementById("convbtn").style.display = "inline";
 		
     }
 


### PR DESCRIPTION
- In Conversation Record page, added a button to show conversation contents. This is because a) it was slow to open the link to see the comment on Steemit. b) The contents cannot be loaded via PHP on SteemSQL, so SteemJS is used instead, a steemJS function is triggered by pressing the button.
- In the Effecitve SP ranking page, an Own SP column was added.
- The See Conversation Record button on the main page now hides when other buttons are pressed.