### PR TITLE
2018-10-30: Tag and Title filters for Article Listing, Stricter rules to filter out comments

### DIFF
--- a/articlelist.php
+++ b/articlelist.php
@@ -3,32 +3,32 @@
 include 'steemSQLconnect2.php';
 // Make your model available
 include 'models/articlelistmodel.php';
-// Get values from URL	
+// Get values from URL  
 // voter details stripped from URL
 if (isset($_GET["voter"])) {
-	$voter = rtrim($_GET["voter"]);
+  $voter = rtrim($_GET["voter"]);
 }     
-// check if date has been entered (submitted via form)	
+// check if date has been entered (submitted via form)
 if (isset($_GET["date"])) {
-	$date = $_GET["date"];
+  $date = $_GET["date"];
 } else {
-	// set date variable for SQL query.
-	$date = date("Y-m-d", strtotime("-1 months"));
+  // set date variable for SQL query.
+  $date = date("Y-m-d", strtotime("-1 months"));
 }     
 // check if to date has been entered (submitted via form)
 if (isset($_GET["toDate"])) {
-	$todate = $_GET["toDate"];
+  $todate = $_GET["toDate"];
 } else { 
-	$todate = date("Y-m-d", strtotime("+1 day"));	
+  $todate = date("Y-m-d", strtotime("+1 day")); 
 }     
 if (isset($_GET["mode"])) {
-	$mode = $_GET["mode"];
-}           	
-// retrieve choice for whether to include articles only or to include comments as well. 
+  $mode = $_GET["mode"];
+}             
+// retrieve choice for whether to include articles only or to include comments as well.
 if (isset($_GET["Articlesonly"])) {
-	$articlesonly = $_GET["Articlesonly"];
+  $articlesonly = $_GET["Articlesonly"];
 } else {
-	$articlesonly = 1;
+  $articlesonly = 1;
 } 
 // retrieve the tag input box value.
 if (isset($_GET["tag"])) {
@@ -48,9 +48,9 @@ if ($voter&&$mode=="upvote") {
   // get list of results
   $results = $articlelistmodel -> gethistory($date,$todate,$voter,$articlesonly,$tag,$title);
 } elseif ($voter&&$mode=="written") {
-  $results = $articlelistmodel -> getwritten($date,$todate,$voter,$articlesonly,$tag,$title);	
-}                                               
+  $results = $articlelistmodel -> getwritten($date,$todate,$voter,$articlesonly,$tag,$title); 
+}
 // Show the view
-include 'views/articlelistview.php';            
-$articlelistmodel -> close_connection();        
-?>                                              
+include 'views/articlelistview.php';
+$articlelistmodel -> close_connection();
+?>

--- a/articlelist.php
+++ b/articlelist.php
@@ -29,14 +29,26 @@ if (isset($_GET["Articlesonly"])) {
 	$articlesonly = $_GET["Articlesonly"];
 } else {
 	$articlesonly = 1;
-}     
+} 
+// retrieve the tag input box value.
+if (isset($_GET["tag"])) {
+  $tag = $_GET["tag"];
+} else {
+  $tag=NULL;
+}
+// retrieve the title input box value.
+if (isset($_GET["title"])) {
+  $title=$_GET["title"];
+} else {
+  $title=NULL;
+}
 // create an instance
 $articlelistmodel = new articlelistmodel($conn);
 if ($voter&&$mode=="upvote") {
-// get list of results
-$results = $articlelistmodel -> gethistory($date,$todate,$voter,$articlesonly);
+  // get list of results
+  $results = $articlelistmodel -> gethistory($date,$todate,$voter,$articlesonly,$tag,$title);
 } elseif ($voter&&$mode=="written") {
-$results = $articlelistmodel -> getwritten($date,$todate,$voter,$articlesonly);	
+  $results = $articlelistmodel -> getwritten($date,$todate,$voter,$articlesonly,$tag,$title);	
 }                                               
 // Show the view
 include 'views/articlelistview.php';            

--- a/models/articlelistmodel.php
+++ b/models/articlelistmodel.php
@@ -1,54 +1,68 @@
 <?php
-class articlelistmodel {	
-	protected $db;        	
-	public function __construct(PDO $db) {		
-		$this->db = $db;
-	}                                     	
-	public function gethistory($date,$todate,$voter,$articlesonly) {
-    // retrieve list of articles voted on by user		
-		$sql = "SELECT timestamp,weight,author,permlink
-				FROM TxVotes 
-				WHERE (voter=:voter) 
-					AND (timestamp>=Convert(datetime, :date)) 
-					AND (timestamp<=Convert(datetime,:todate))";
-    // if comments are excluded, add this to SQL
+class articlelistmodel {
+  protected $db;
+  public function __construct(PDO $db) {
+    $this->db = $db;
+  }
+  public function gethistory($date,$todate,$voter,$articlesonly,$tag,$title) {
+    // retrieve list of articles voted on by user
+    $sql = "SELECT timestamp,weight,TxVotes.author,TxVotes.permlink
+            FROM TxVotes LEFT OUTER JOIN Comments
+            ON (TxVotes.author=Comments.author AND TxVotes.permlink=Comments.permlink)
+            WHERE (voter=:voter)
+            AND (timestamp>=Convert(datetime, :date))
+            AND (timestamp<=Convert(datetime,:todate))";
+      // if comments are excluded, add this to SQL
     if ($articlesonly==2) {
-      $sql.= "AND (permlink NOT LIKE 're-%')";
-    }                                                                                         
-		$sql.="ORDER BY timestamp DESC";                                 		
-		$result = $this->db->prepare($sql);                           		
-		$result -> bindValue(':date', $date, PDO::PARAM_STR);
-		$result -> bindValue(':todate', $todate, PDO::PARAM_STR);
-		$result -> bindValue(':voter', $voter, PDO::PARAM_STR);       		
-		$result->execute();                                           		
-		return $result;
-	}             	
-	public function getwritten($date,$todate,$author,$articlesonly) {
+      $sql.= "AND (Comments.depth=0)";
+    }
+      // if there is a tag specified, add this to SQL
+    if ($tag!=NULL) {
+      $sql.="AND (CONTAINS(Comments.json_metadata, '".$tag."'))";
+    }
+    if ($title!=NULL) {
+      $sql.="AND (CONTAINS(Comments.title, '".$title."'))";
+    }
+    $sql.="ORDER BY timestamp DESC";
+    $result = $this->db->prepare($sql);
+    $result -> bindValue(':date', $date, PDO::PARAM_STR);
+    $result -> bindValue(':todate', $todate, PDO::PARAM_STR);
+    $result -> bindValue(':voter', $voter, PDO::PARAM_STR);
+    $result->execute();
+    return $result;
+  }
+  public function getwritten($date,$todate,$author,$articlesonly,$tag,$title) {
     // retrieve list of articles written by user
-		$sql = "SELECT author,permlink,created AS timestamp
-				FROM Comments 
-				WHERE (author =:author) 
-				AND (created>=Convert(datetime, :date)) 
-				AND (created<=Convert(datetime,:todate))";
+    $sql = "SELECT author,permlink,created AS timestamp
+            FROM Comments
+            WHERE (author =:author)
+            AND (created>=Convert(datetime,:date))
+            AND (created<=Convert(datetime,:todate))
+            ";
     // if comments are excluded, add this to SQL
     if ($articlesonly==2) {
       $sql.= "AND (depth=0)";
-    }   
-		$sql.="ORDER BY created DESC";
-		$result = $this->db->prepare($sql);	
-		$result -> bindValue(':date', $date, PDO::PARAM_STR);
-		$result -> bindValue(':todate', $todate, PDO::PARAM_STR);
-		$result -> bindValue(':author', $author, PDO::PARAM_STR);
-		$result->execute();
-		return $result;
-	}
-	
-	public function close_connection() {
-        if(isset($this->db))
-        {
-            $this->db->close();
-            unset($this->db);
-        }
     }
-	
+    // if there is a tag specified, add this to SQL
+    if ($tag!=NULL) {
+      $sql.="AND (CONTAINS(json_metadata, '".$tag."'))";
+    }
+    // if there is a title specified, add this to SQL
+    if ($title!=NULL) {
+      $sql.="AND (CONTAINS(title, '".$title."'))";
+    }
+    $sql.="ORDER BY created DESC";
+    $result = $this->db->prepare($sql); 
+    $result -> bindValue(':date', $date, PDO::PARAM_STR);
+    $result -> bindValue(':todate', $todate, PDO::PARAM_STR);
+    $result -> bindValue(':author', $author, PDO::PARAM_STR);
+    $result->execute();
+    return $result;
+  }
+  public function close_connection() {
+    if(isset($this->db)) {
+      $this->db->close();
+      unset($this->db);
+    }
+  }
 }

--- a/views/articlelistview.php
+++ b/views/articlelistview.php
@@ -1,51 +1,59 @@
 <html>
   <head>
-	<title>My Steemit Friends</title>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<link rel="stylesheet" href="bootstrap/css/bootstrap.min.css">
-	<script src="jquery/jquery-3.2.1.min.js"></script>
-	<script src="popper.min.js"></script>
-	<script src="bootstrap/js/bootstrap.min.js"></script>
-	<link rel="stylesheet" type="text/css" href="style.css?3">
-	<style>
-		.navbutton {
-			width: 10rem;
-			margin: 0.5rem;
-		}
-	</style>
+  <title>My Steemit Friends</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="bootstrap/css/bootstrap.min.css">
+  <script src="jquery/jquery-3.2.1.min.js"></script>
+  <script src="popper.min.js"></script>
+  <script src="bootstrap/js/bootstrap.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="style.css?3">
+  <style>
+    .navbutton {
+      width: 10rem;
+      margin: 0.5rem;
+    }
+  </style>
   </head>
   <body>
 <!-- navbar -->
-<? include 'views/navbar.php'; ?>	
+<? include 'views/navbar.php'; ?> 
     <!-- main page container -->
     <div class="container-fluid bg-1 text-center">  
 <? include 'views/notifications.php'; ?>
       <!-- form for obtaining user input -->
-		  <form class="form-inline justify-content-center" onSubmit="return false">
-  			<div class="form-group" style="margin-top:10px;">
-  				<label for="voter">User:&nbsp;</label>
-  				<input class="form-control" placeholder="<?
+      <form class="form-inline justify-content-center" onSubmit="return false">
+        <div class="form-group" style="margin-top:10px;">
+          <label for="voter">User:&nbsp;</label>
+          <input class="form-control" placeholder="<?
   if ($mode=="upvote") {
-  echo "Voter";
+    echo "Voter";
   } else {
-  echo "Author";
+    echo "Author";
   }
           ?> Username" id="voter" type="text" size="15" name="voter" value="<? if (isset($voter)) {echo $voter;} ?>" autofocus>&nbsp;&nbsp;
-  			</div>
-  			<div class="form-group" style="margin-top:10px;">
-  				<label for="fromDate">From Date:&nbsp;</label>
-  				<input class="form-control" name="date" id="date" type="date" value="<? if (isset($newdate)) {echo $newdate;} else {echo $date;} ?>" id="date" min="2016-03-30" max="<?echo date(" Y-m-d "); ?>">&nbsp;&nbsp;
-  			</div>
-  			<div class="form-group" style="margin-top:10px;">
-  				<label for="toDate">To Date:&nbsp;</label>
-  				<input class="form-control" name="toDate" id="toDate" type="date" value="<? if (isset($todate)) {echo $todate;} else {echo date(" Y-m-d ",strtotime("+1 day "));} ?>" id="toDate" min="2016-03-30" max="<?echo date(" Y-m-d ",strtotime("+1 day ")); ?>">&nbsp;&nbsp;
-  			</div>
-  			<div class="form-group" style="margin-top:10px;">  		
-      		<input class="form-control" name="Articlesonly" type="checkbox" value="2" id="Articlesonly"<? if ($articlesonly==2) {echo " checked";} ?>>&nbsp;
-      		<label for="articlesonly">Exclude comments&nbsp;&nbsp;</label>  
-    		</div>             
-		  </form>
+        </div>
+        <div class="form-group" style="margin-top:10px;">
+          <label for="fromDate">From Date:&nbsp;</label>
+          <input class="form-control" name="date" id="date" type="date" value="<? if (isset($newdate)) {echo $newdate;} else {echo $date;} ?>" id="date" min="2016-03-30" max="<?echo date(" Y-m-d "); ?>">&nbsp;&nbsp;
+        </div>
+        <div class="form-group" style="margin-top:10px;">
+          <label for="toDate">To Date:&nbsp;</label>
+          <input class="form-control" name="toDate" id="toDate" type="date" value="<? if (isset($todate)) {echo $todate;} else {echo date(" Y-m-d ",strtotime("+1 day "));} ?>" id="toDate" min="2016-03-30" max="<?echo date(" Y-m-d ",strtotime("+1 day ")); ?>">&nbsp;&nbsp;
+        </div>
+        <div class="form-group" style="margin-top:10px;">
+          <label for="tag">Tags contain:&nbsp;&nbsp;</label>
+          <input class="form-control" name="tag" id="tag" type="text" size="5" value="<?if (isset($tag)) {echo $tag;}?>">&nbsp;&nbsp;
+        </div>
+        <div class="form-group" style="margin-top:10px;">
+          <label for="title">Title contains:&nbsp;&nbsp;</label>
+          <input class="form-control" name="title" id="title" type="text" size="10" value="<?if (isset($title)) {echo $title;}?>">&nbsp;&nbsp;
+        </div>
+        <div class="form-group" style="margin-top:10px;">
+          <input class="form-control" name="Articlesonly" type="checkbox" value="2" id="Articlesonly"<? if ($articlesonly==2) {echo " checked";} ?>>&nbsp;
+          <label for="Articlesonly">Exclude comments&nbsp;&nbsp;</label>  
+        </div>
+      </form>
        <?
       if ($mode=="upvote") {
         echo '<button id="upvotebtn" class="btn btn-lg btn-primary" style="margin-top:10px;">List Articles Upvoted</button>';        
@@ -53,60 +61,60 @@
         echo '<button id="writtenbtn" class="btn btn-lg btn-primary" style="margin-top:10px;">List Articles Written</button>';
       }
       ?>
-
       <br><br>
-		  
-<?    	
-// title at the top of page to state the voter and who is the author	
+<?
+// title at the top of page to state the voter and who is the author  
 if (isset($results)) {
-	// depending on whether the user clicked Voted or Written, display different table headings.
-	if ($mode=='upvote') {
-		echo '<p><a href="http://steemit.com/@'.$voter.'"><b>@'.$voter.'</b></a> upvoted the following:</p>';
-		$headings=array("Timestamp", "%", "Author", "Link");
-	}	
-	if ($mode=='written') {
-		echo '<p><a href="http://steemit.com/@'.$voter.'"><b>@'.$voter.'</b></a> wrote the following:</p>';
-		$headings=array("Timestamp", "Author","Link");
-	}  
-	// table begins here
-	echo '<table class="table table-sm"><thead class="thead-inverse"><tr>'; 	
-	// generate table headings
-	for ($x=0;$x<count($headings);$x++) {
-		echo '<th>';
-		echo $headings[$x];
-		echo '</th>';		
-	}
-	// end of table headings, start of table body
-	echo '</tr></thead><tbody>';
+  // depending on whether the user clicked Voted or Written, display different table headings.
+  if ($mode=='upvote') {
+    echo '<p><a href="http://steemit.com/@'.$voter.'"><b>@'.$voter.'</b></a> upvoted the following:</p>';
+    $headings=array("Timestamp", "%", "Author", "Link");
+  } 
+  if ($mode=='written') {
+    echo '<p><a href="http://steemit.com/@'.$voter.'"><b>@'.$voter.'</b></a> wrote the following:</p>';
+    $headings=array("Timestamp", "Author","Link");
+  }  
+  // table begins here
+  echo '<table class="table table-sm"><thead class="thead-inverse"><tr>';   
+  // generate table headings
+  for ($x=0;$x<count($headings);$x++) {
+    echo '<th>';
+    echo $headings[$x];
+    echo '</th>';   
+  }
+  // end of table headings, start of table body
+  echo '</tr></thead><tbody>';
 foreach ($results as $row) {
-	echo "<tr>";
-	echo "<td>";
-	echo $row['timestamp'];
-	echo "</td>";
-	if ($mode=='upvote') {
-		echo "<td>";
-		echo $row['weight']/100;
-		echo "</td>";
-	}
-	echo "<td>";
-	echo $row['author'];
-	echo "</td>";
-	echo "<td>";
-	echo '<p><a href="https://steemit.com/cn/@'.$row['author'].'/'.$row['permlink'].'" target="_top">'.$row['permlink'].'</a></p>';  
+  echo "<tr>";
+  echo "<td>";
+  echo $row['timestamp'];
+  echo "</td>";
+  if ($mode=='upvote') {
+    echo "<td>";
+    echo $row['weight']/100;
     echo "</td>";
-	echo "</tr>";
-	} 
-}                             
-echo "</tbody></table>";      	
-?>    
-    </div>	
+  }
+  echo "<td>";
+  echo $row['author'];
+  echo "</td>";
+  echo "<td>";
+  echo '<p><a href="https://steemit.com/cn/@'.$row['author'].'/'.$row['permlink'].'" target="_top">'.$row['permlink'].'</a></p>';  
+    echo "</td>";
+  echo "</tr>";
+  } 
+}
+echo "</tbody></table>";
+?>
+    </div>  
   </body>   
-  <!-- Javascript -->	
-  <script>	
+  <!-- Javascript --> 
+  <script>  
     function retrieveInput() {
-    	goToUser = document.getElementById("voter").value;
-    	date = document.getElementById("date").value;
-    	toDate = document.getElementById("toDate").value;
+      title = document.getElementById("title").value;    
+      tag = document.getElementById("tag").value;
+      goToUser = document.getElementById("voter").value;
+      date = document.getElementById("date").value;
+      toDate = document.getElementById("toDate").value;
       // find out whether comments are included in article list
       mycheck = document.getElementById("Articlesonly").checked;
       if (mycheck==true) {
@@ -115,20 +123,16 @@ echo "</tbody></table>";
       {
         mycheck=1;
       }
-    }	
+    } 
     $(function(){
-    	$("#upvotebtn").click(
-    	  function() {		      
-    		  retrieveInput();
-    			  window.location.href = 'articlelist.php?mode=upvote&Articlesonly='+mycheck+'&voter='+goToUser+'&date='+date+'&toDate='+toDate;			  
-    		}	  
-    	);	       	
-    	$("#writtenbtn").click(
-    	  function() {	
-    		  retrieveInput();
-    			window.location.href = 'articlelist.php?mode=written&Articlesonly='+mycheck+'&voter='+goToUser+'&date='+date+'&toDate='+toDate;			  
-    		}	  
-    	);	       	
-    });          	
-  </script>	
+      $("#upvotebtn").click(function() {
+        retrieveInput();
+      window.location.href = 'articlelist.php?mode=upvote&Articlesonly='+mycheck+'&voter='+goToUser+'&date='+date+'&toDate='+toDate+'&tag='+tag+'&title='+title;      
+      });         
+      $("#writtenbtn").click(function() { 
+      retrieveInput();
+      window.location.href = 'articlelist.php?mode=written&Articlesonly='+mycheck+'&voter='+goToUser+'&date='+date+'&toDate='+toDate+'&tag='+tag+'&title='+title;       
+      });         
+    });           
+  </script> 
 </html>


### PR DESCRIPTION
3 files were updated in this pull request:

articlelist.php
Controller gathers input for tag and title
The controller for article list now gathers Input for both the tag and the title filters set by the user. It then passes these to the models to retrieve data (list of articles filtered by tag and title).

articlelistmodel.php
Added tag and title filters to both votes and written articles 
For both Written Articles and Voted Articles queries, the $tag and $title filters from the controller have been used to filter query results. If the user types a tag or a title or both into the form, the result will return articles matching their request.
The Written Articles query has also been re-written so that it does not rely on the "re-" prefix in the permlink to filter out comments. Rather, the TxVotes table has been joined with the Comments table using the author column as well as the permlink column, to use the depth field in the Comments table to filter out comments.

articlelistview.php
Added two input boxes for tag and title 
Two input boxes have been added to the form: 
- The user can now enter a tag they want to filter the article list against.
- The user can now enter a title they want to filter the article list against.
Both input boxes will work in both modes (Written & Upvoted articles).